### PR TITLE
iOSのホームの並び替え

### DIFF
--- a/Casical.xcodeproj/project.pbxproj
+++ b/Casical.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		AB7AC68C272985BC007069BC /* CasicalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7AC68B272985BC007069BC /* CasicalTests.swift */; };
 		AB7AC696272985BC007069BC /* CasicalUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7AC695272985BC007069BC /* CasicalUITests.swift */; };
 		AB7AC698272985BC007069BC /* CasicalUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7AC697272985BC007069BC /* CasicalUITestsLaunchTests.swift */; };
+		ABCDE64A272E38B400BB34A3 /* SampleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDE649272E38B400BB34A3 /* SampleModel.swift */; };
 		ABD46A81272B03E5006AB17A /* Login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ABD46A7F272B03E5006AB17A /* Login.storyboard */; };
 		ABD46A82272B03E5006AB17A /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD46A80272B03E5006AB17A /* LoginViewController.swift */; };
 		ABD46A84272B2AD4006AB17A /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD46A83272B2AD4006AB17A /* UIColor+Extension.swift */; };
@@ -88,6 +89,7 @@
 		AB7AC695272985BC007069BC /* CasicalUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CasicalUITests.swift; sourceTree = "<group>"; };
 		AB7AC697272985BC007069BC /* CasicalUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CasicalUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		AB7AC6A4272985C1007069BC /* Casical.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Casical.entitlements; sourceTree = "<group>"; };
+		ABCDE649272E38B400BB34A3 /* SampleModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleModel.swift; sourceTree = "<group>"; };
 		ABD46A7F272B03E5006AB17A /* Login.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Login.storyboard; sourceTree = "<group>"; };
 		ABD46A80272B03E5006AB17A /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		ABD46A83272B2AD4006AB17A /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 		AB7AC673272985BA007069BC /* Casical */ = {
 			isa = PBXGroup;
 			children = (
+				ABCDE648272E38A500BB34A3 /* Model */,
 				ABF581AE272D4FAB0086D60E /* Setting */,
 				ABF581A8272D4F580086D60E /* ProfileAdditional */,
 				ABF581A2272D4F120086D60E /* PersonalPage */,
@@ -208,6 +211,14 @@
 				AB7AC697272985BC007069BC /* CasicalUITestsLaunchTests.swift */,
 			);
 			path = CasicalUITests;
+			sourceTree = "<group>";
+		};
+		ABCDE648272E38A500BB34A3 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				ABCDE649272E38B400BB34A3 /* SampleModel.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		ABD46A7E272B03E5006AB17A /* Login */ = {
@@ -627,6 +638,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ABD46A9D272C21FA006AB17A /* UIResponder+Extension.swift in Sources */,
+				ABCDE64A272E38B400BB34A3 /* SampleModel.swift in Sources */,
 				ABF5819F272D4DA70086D60E /* MacHomeViewController.swift in Sources */,
 				ABD46A82272B03E5006AB17A /* LoginViewController.swift in Sources */,
 				AB12F0F8272D60CC00A0FA60 /* SortTableViewCell.swift in Sources */,

--- a/Casical/Home/Cell/ProfileCollectionViewCell.swift
+++ b/Casical/Home/Cell/ProfileCollectionViewCell.swift
@@ -60,7 +60,7 @@ final class ProfileCollectionViewCell: UICollectionViewCell {
         nameLabel.text = model.name
         languageLabel.text = "● " + model.language
         houseLabel.text = "● " + model.house
-        experienceLabel.text = "● " + model.experience
+        experienceLabel.text = "● " + model.convertExperienceToString()
     }
 
 }

--- a/Casical/Home/iOS/HomeViewController.swift
+++ b/Casical/Home/iOS/HomeViewController.swift
@@ -8,25 +8,6 @@
 import UIKit
 import FirebaseAuth
 
-struct SampleModel {
-    let image: UIImage
-    let name: String
-    let language: String
-    let house: String
-    let experience: String
-    let github: String
-    let qiita: String
-    let bio: String
-}
-
-extension SampleModel {
-    static let data = [SampleModel(image: UIImage(named: "reon")!, name: "OONISHI REON", language: "Swift", house: "東京", experience: "1年", github: "Reon0429-cat", qiita: "REON", bio: "iOSエンジニアを目指してます！Swift大好き！"),
-                       SampleModel(image: UIImage(named: "adu")!, name: "Azuki Yamada", language: "CSS", house: "大阪", experience: "6ヶ月", github: "aduGitHub", qiita: "aduQiita", bio: "aduBio"),
-                       SampleModel(image: UIImage(named: "sakura")!, name: "宮脇 咲良", language: "JavaScript", house: "鹿児島", experience: "5年6ヶ月", github: "sakuraGitHub", qiita: "sakuraQiita", bio: "sakuraBio"),
-                       SampleModel(image: UIImage(named: "mai")!, name: "Mai Shiraishi", language: "Java", house: "群馬", experience: "中途未経験", github: "maiGitHub", qiita: "maiQiita", bio: "maiBio"),
-                       SampleModel(image: UIImage(named: "asuka")!, name: "齋藤 飛鳥", language: "PHP", house: "東京", experience: "新卒未経験", github: "asukaGitHub", qiita: "asukaQiita", bio: "asukaBio"),]
-}
-
 private enum SortButtonFollowViewPosition {
     case score(UIButton)
     case register(UIButton)
@@ -55,7 +36,7 @@ final class HomeViewController: UIViewController {
     @IBOutlet private weak var settingButton: UIButton!
     @IBOutlet private weak var separatorView: UIView!
     
-    private let sampleData = [[SampleModel]](repeating: SampleModel.data, count: 10).flatMap { $0 }
+    private let sampleData = SampleModel.data
     private lazy var sortButtonFollowViewPosition: SortButtonFollowViewPosition = .register(sortRegisterButton)
     
     override func viewDidLoad() {

--- a/Casical/Home/iOS/HomeViewController.swift
+++ b/Casical/Home/iOS/HomeViewController.swift
@@ -36,8 +36,22 @@ final class HomeViewController: UIViewController {
     @IBOutlet private weak var settingButton: UIButton!
     @IBOutlet private weak var separatorView: UIView!
     
-    private let sampleData = SampleModel.data
+    private var sampleData = SampleModel.data
     private lazy var sortButtonFollowViewPosition: SortButtonFollowViewPosition = .register(sortRegisterButton)
+    private enum SortType {
+        case score
+        case register
+        case experience
+        
+        var condition: (SampleModel, SampleModel) -> Bool {
+            switch self {
+                case .score: return { $0.skillScore > $1.skillScore }
+                case .register: return { $0.registrationDate < $1.registrationDate }
+                case .experience: return { $0.experience > $1.experience }
+            }
+        }
+    }
+    private var sortType: SortType = .register
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -46,29 +60,37 @@ final class HomeViewController: UIViewController {
         if isNotLoggedIn {
             presentLoginVC()
         }
-        
+        rearranges(sortType: .register)
         setupUI()
         
     }
     
     @IBAction private func sortScoreButton(_ sender: Any) {
         changeFollowViewPosition(to: sortScoreButton)
+        rearranges(sortType: .score)
     }
     
     @IBAction private func sortRegisterButton(_ sender: Any) {
         changeFollowViewPosition(to: sortRegisterButton)
+        rearranges(sortType: .register)
     }
     
     @IBAction private func sortExperienceButton(_ sender: Any) {
         changeFollowViewPosition(to: sortExperienceButton)
+        rearranges(sortType: .experience)
     }
     
     @IBAction private func filterButton(_ sender: Any) {
-        
+        // 実装しない
     }
     
     @IBAction private func settingButton(_ sender: Any) {
         
+    }
+    
+    private func rearranges(sortType: SortType) {
+        sampleData = sampleData.sorted(by: sortType.condition)
+        collectionView.reloadData()
     }
     
     private func presentLoginVC() {

--- a/Casical/Model/SampleModel.swift
+++ b/Casical/Model/SampleModel.swift
@@ -1,0 +1,79 @@
+//
+//  SampleModel.swift
+//  Casical
+//
+//  Created by 大西玲音 on 2021/10/31.
+//
+
+import UIKit
+
+struct SampleModel {
+    let image: UIImage
+    let name: String
+    let language: String
+    let house: String
+    let experience: String
+    let github: String
+    let qiita: String
+    let bio: String
+    let skillScore: Int
+    let registrationDate: Date
+    
+    private static func date(value: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: value, to: Date())!
+    }
+}
+
+extension SampleModel {
+    static let data = [
+        SampleModel(image: UIImage(named: "reon")!,
+                    name: "OONISHI REON",
+                    language: "Swift",
+                    house: "東京",
+                    experience: "1年",
+                    github: "Reon0429-cat",
+                    qiita: "REON",
+                    bio: "iOSエンジニアを目指してます！Swift大好き！",
+                    skillScore: 100,
+                    registrationDate: date(value: 10)),
+        SampleModel(image: UIImage(named: "adu")!,
+                    name: "Azuki Yamada",
+                    language: "CSS",
+                    house: "大阪",
+                    experience: "6ヶ月",
+                    github: "aduGitHub",
+                    qiita: "aduQiita",
+                    bio: "aduBio",
+                    skillScore: 120,
+                    registrationDate: date(value: 40)),
+        SampleModel(image: UIImage(named: "sakura")!,
+                    name: "宮脇 咲良",
+                    language: "JavaScript",
+                    house: "鹿児島",
+                    experience: "5年6ヶ月",
+                    github: "sakuraGitHub",
+                    qiita: "sakuraQiita",
+                    bio: "sakuraBio",
+                    skillScore: 40,
+                    registrationDate: date(value: 10)),
+        SampleModel(image: UIImage(named: "mai")!,
+                    name: "Mai Shiraishi",
+                    language: "Java",
+                    house: "群馬",
+                    experience: "中途未経験",
+                    github: "maiGitHub",
+                    qiita: "maiQiita",
+                    bio: "maiBio",
+                    skillScore: 200,
+                    registrationDate: date(value: 60)),
+        SampleModel(image: UIImage(named: "asuka")!,
+                    name: "齋藤 飛鳥",
+                    language: "PHP",
+                    house: "東京",
+                    experience: "新卒未経験",
+                    github: "asukaGitHub",
+                    qiita: "asukaQiita",
+                    bio: "asukaBio",
+                    skillScore: 250,
+                    registrationDate: date(value: 100)),]
+}

--- a/Casical/Model/SampleModel.swift
+++ b/Casical/Model/SampleModel.swift
@@ -12,17 +12,19 @@ struct SampleModel {
     let name: String
     let language: String
     let house: String
-    let experience: String
+    let experience: Int
     let github: String
     let qiita: String
     let bio: String
     let skillScore: Int
     let registrationDate: Date
-    
     private static func date(value: Int) -> Date {
         Calendar.current.date(byAdding: .day, value: value, to: Date())!
     }
 }
+
+// experience: 3年10ヶ月 => 3 * 12 + 10 = 46
+// 未経験 => 0
 
 extension SampleModel {
     static let data = [
@@ -30,7 +32,7 @@ extension SampleModel {
                     name: "OONISHI REON",
                     language: "Swift",
                     house: "東京",
-                    experience: "1年",
+                    experience: 12,
                     github: "Reon0429-cat",
                     qiita: "REON",
                     bio: "iOSエンジニアを目指してます！Swift大好き！",
@@ -40,27 +42,27 @@ extension SampleModel {
                     name: "Azuki Yamada",
                     language: "CSS",
                     house: "大阪",
-                    experience: "6ヶ月",
+                    experience: 6,
                     github: "aduGitHub",
                     qiita: "aduQiita",
                     bio: "aduBio",
                     skillScore: 120,
-                    registrationDate: date(value: 40)),
+                    registrationDate: date(value: 20)),
         SampleModel(image: UIImage(named: "sakura")!,
                     name: "宮脇 咲良",
                     language: "JavaScript",
                     house: "鹿児島",
-                    experience: "5年6ヶ月",
+                    experience: 66,
                     github: "sakuraGitHub",
                     qiita: "sakuraQiita",
                     bio: "sakuraBio",
                     skillScore: 40,
-                    registrationDate: date(value: 10)),
+                    registrationDate: date(value: 30)),
         SampleModel(image: UIImage(named: "mai")!,
                     name: "Mai Shiraishi",
                     language: "Java",
                     house: "群馬",
-                    experience: "中途未経験",
+                    experience: 0,
                     github: "maiGitHub",
                     qiita: "maiQiita",
                     bio: "maiBio",
@@ -70,10 +72,31 @@ extension SampleModel {
                     name: "齋藤 飛鳥",
                     language: "PHP",
                     house: "東京",
-                    experience: "新卒未経験",
+                    experience: 0,
                     github: "asukaGitHub",
                     qiita: "asukaQiita",
                     bio: "asukaBio",
                     skillScore: 250,
-                    registrationDate: date(value: 100)),]
+                    registrationDate: date(value: 100)),
+    ]
+}
+
+extension SampleModel {
+    
+    func convertExperienceToString() -> String {
+        let year = self.experience / 12
+        let month = self.experience % 12
+        if year == 0, month == 0 {
+            return "未経験"
+        } else if year == 0, month != 0 {
+            return "\(month)ヶ月"
+        } else if year != 0, month == 0 {
+            return "\(year)年"
+        } else if year != 0, month != 0 {
+            return "\(year)年\(month)ヶ月"
+        } else {
+            return ""
+        }
+    }
+    
 }

--- a/Casical/PersonalPage/Mac/MacPersonalPageViewController.swift
+++ b/Casical/PersonalPage/Mac/MacPersonalPageViewController.swift
@@ -61,10 +61,8 @@ private extension MacPersonalPageViewController {
     
     func setupPersonalData() {
         nameLabel.text = sampleModel?.name
-        let houseText = sampleModel?.house ?? "登録されていません"
-        let experienceText = sampleModel?.experience ?? "登録されていません"
-        houseLabel.text = "● " + houseText
-        experienceLabel.text = "● " + experienceText
+        houseLabel.text = "● " + sampleModel!.house
+        experienceLabel.text = "● " + sampleModel!.convertExperienceToString()
         profileImageView.image = sampleModel?.image
         profileImageView.layer.cornerRadius = profileImageView.frame.height / 2
         bioLabel.text = sampleModel?.bio


### PR DESCRIPTION
#12 

・やったこと
SampleModelをいじった
ホームのプロフィールをスコア、登録順、経験年数で並び替えられるようにした。

・質問
なし

・備考
あとは本番用APIと差し替えるだけ(多分)

・挙動

https://user-images.githubusercontent.com/66917548/139566254-cf401b92-9007-467d-b548-4135988f3071.mov


